### PR TITLE
Implementation of mass_balance_check() and energy_balance_check() trait functions in blocks module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 name = "oscps-lib"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "uom",
 ]
 

--- a/oscps-gui/package.json
+++ b/oscps-gui/package.json
@@ -34,5 +34,8 @@
   "type": "module",
   "dependencies": {
     "@tauri-apps/api": "^1.5.6"
-  }
+  },
+  "trustedDependencies": [
+    "svelte-preprocess"
+  ]
 }

--- a/oscps-lib/Cargo.toml
+++ b/oscps-lib/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 uom  = "0.36.0"
+once_cell = "1.17.1"

--- a/oscps-lib/src/blocks.rs
+++ b/oscps-lib/src/blocks.rs
@@ -18,6 +18,7 @@ use once_cell::sync::Lazy;
 //Initiallizing a global variable for the tolerance for the energy balance
 static TOLERENCE_ENERGY: Lazy<Energy> = Lazy::new(|| Energy::new::<joule>(5.0));
 
+//Initiallizing a global variable for the tolerance for the mass balance
 static TOLERENCE_MASS: Lazy<Mass> = Lazy::new(|| Mass::new::<kilogram>(5.0));
 
 /// Trait for ensuring the overall mass balance is maintained in a flowsheet.

--- a/oscps-lib/src/blocks.rs
+++ b/oscps-lib/src/blocks.rs
@@ -60,12 +60,14 @@ mod block_tests {
     use std::io;
     
     #[test]
-    fn mass_balance_check_mixer_blk() {
-
+    fn mass_balance_check_mixer_blk() -> io::Result<()> {
+        // here you will need to check that the mass into the mixer = mass out of mixer
+        return Ok(());
     }
 
     #[test]
-    fn energy_balance_check_mixer_blk() {
-
+    fn energy_balance_check_mixer_blk() -> io::Result<()> {
+        // energy into mixer = energy out of mixer
+        return Ok(())
     }
 }

--- a/oscps-lib/src/blocks.rs
+++ b/oscps-lib/src/blocks.rs
@@ -94,7 +94,8 @@ mod block_tests {
     use super::*;
     use std::io;
     use uom::si::f64::Energy;
-    use uom::si::energy::joule;
+    use uom::si::energy::kilojoule;
+    use uom::si::mass::pound;
     
     #[test]
     fn test_mass_balance_check_steady_state_for_mixer() {
@@ -103,8 +104,8 @@ mod block_tests {
         let mixer_test_obj = Mixer{
             block_id : String::from("Test Mixer")
         };
-        let mass_in = Mass::new::<kilogram>(100.0);
-        let mass_out = Mass::new::<kilogram>(95.0);
+        let mass_in = Mass::new::<pound>(100.0);
+        let mass_out = Mass::new::<pound>(95.0);
         assert!(mixer_test_obj.mass_balance_check(mass_in, mass_out));
     }
 
@@ -114,8 +115,8 @@ mod block_tests {
         let mixer_test_obj = Mixer{
             block_id : String::from("Test Mixer")
         };
-        let energy_in = Energy::new::<joule>(10.0);
-        let energy_out = Energy::new::<joule>(95.0);
+        let energy_in = Energy::new::<kilojoule>(10.0);
+        let energy_out = Energy::new::<kilojoule>(95.0);
         assert!(mixer_test_obj.energy_balance_check(energy_in, energy_out));
     }
 }

--- a/oscps-lib/src/blocks.rs
+++ b/oscps-lib/src/blocks.rs
@@ -4,33 +4,51 @@
 //! implemented by various structs to represent different unit operations.
 //!
 //! For example, if a block is a simple mixer, then it will implement the
-//! MassBalance trait but not th
+//! MassBalance trait but not the EnergyBalance.
 //!
 
-// use crate::connector;
+use crate::connector;
 
-// trait MassBalance {
-//     fn overall_massive_balance() {}
-// }
+/// Trait for ensuring the overall mass balance is maintained in a flowsheet.
+///
+/// This trait can be implemented by any block that needs to ensure mass conservation.
+trait MassBalance {
+    fn overall_mass_balance() {}
+}
 
-// trait EnergyBalance {
-//     fn energy_balance(){}
-// }
+/// # EnergyBalance
+///
+/// This trait ensures that blocks in the flowsheet adhere to energy conservation principles.
+///
+/// This is useful for distinguishing between "dynamic" and "steady state" simulations.
+trait EnergyBalance {
+    fn energy_balance() {}
+}
 
-// trait ElementBalance {
-//     fn element_balance(){}
-// }
+/// # ElementBalance (also known as Atomic Balance)
+///
+/// This trait ensures atomic conservation, especially relevant in reactor simulations.
+///
+/// Similar to the EnergyBalance trait, this is useful for determining the nature of the simulation (dynamic or steady state).
+trait ElementBalance {
+    fn element_balance() {}
+}
 
-// pub struct Mixer{
-//     pub block_id: String,
-//     pub input_stream: Vec<connector::Mconnector>,
-//     pub output_stream: connector::Mconnector
-// }
+/// # Mixer Block
+/// 
+/// A block used for simple stream mixing operations.
+/// 
+/// This struct requires the implementation of both EnergyBalance and MassBalance traits to ensure proper conservation principles are followed.
+pub struct Mixer {
+    pub block_id: String,
+    pub input_stream: Vec<connector::Mconnector>,
+    pub output_stream: connector::Mconnector,
+}
 
-// impl MassBalance for Mixer{
+impl MassBalance for Mixer {
+    // Implement mass balance methods specific to Mixer here.
+}
 
-// }
-
-// impl EnergyBalance for Mixer{
-
-// }
+impl EnergyBalance for Mixer {
+    // Implement energy balance methods specific to Mixer here.
+}

--- a/oscps-lib/src/blocks.rs
+++ b/oscps-lib/src/blocks.rs
@@ -68,6 +68,6 @@ mod block_tests {
     #[test]
     fn energy_balance_check_mixer_blk() -> io::Result<()> {
         // energy into mixer = energy out of mixer
-        return Ok(())
+        return Ok(());
     }
 }

--- a/oscps-lib/src/blocks.rs
+++ b/oscps-lib/src/blocks.rs
@@ -52,3 +52,20 @@ impl MassBalance for Mixer {
 impl EnergyBalance for Mixer {
     // Implement energy balance methods specific to Mixer here.
 }
+
+
+#[cfg(test)]
+mod block_tests {
+    use super::*;
+    use std::io;
+    
+    #[test]
+    fn mass_balance_check_mixer_blk() {
+
+    }
+
+    #[test]
+    fn energy_balance_check_mixer_blk() {
+
+    }
+}

--- a/oscps-lib/src/component.rs
+++ b/oscps-lib/src/component.rs
@@ -57,16 +57,20 @@ impl ChemicalProperties {
     }
 }
 
-use std::io;
-use uom::si::thermodynamic_temperature::kelvin;
+#[cfg(test)]
+mod component_tests {
+    use super::*;
+    use std::io;
+    use uom::si::thermodynamic_temperature::kelvin;
 
-#[test]
-fn test_chemical_properties_constructor() -> io::Result<()> {
-    // Test using water
-    let water_melting_point = ThermodynamicTemperature::new::<kelvin>(273.15);
-    let water_boiling_point = ThermodynamicTemperature::new::<kelvin>(373.15);
-    let water_properties = ChemicalProperties::new(water_melting_point, water_boiling_point);
-    assert_eq!(water_properties.normal_melting_point, water_melting_point);
-    assert_eq!(water_properties.normal_boiling_point, water_boiling_point);
-    Ok(()) 
+    #[test]
+    fn test_chemical_properties_constructor() -> io::Result<()> {
+        // Test using water
+        let water_melting_point = ThermodynamicTemperature::new::<kelvin>(273.15);
+        let water_boiling_point = ThermodynamicTemperature::new::<kelvin>(373.15);
+        let water_properties = ChemicalProperties::new(water_melting_point, water_boiling_point);
+        assert_eq!(water_properties.normal_melting_point, water_melting_point);
+        assert_eq!(water_properties.normal_boiling_point, water_boiling_point);
+        Ok(()) 
+    }
 }

--- a/oscps-lib/src/connector.rs
+++ b/oscps-lib/src/connector.rs
@@ -1,11 +1,11 @@
-//here we will have 2 connector structs
-    //- Mass Streams
-    //- Energy Streams
-// pub struct Mconnector{
-//     m_conn_id: String
-// }
+//!here we will have 2 connector structs
+    //!- Mass Streams
+    //!- Energy Streams
+pub struct Mconnector{
+    m_conn_id: String
+}
 
-// pub struct Econnector{
-//     e_conn_id: String
-// }
+pub struct Econnector{
+    e_conn_id: String
+}
 


### PR DESCRIPTION
For this PR I have implemented basic functionality for the mass_balance_check() and energy_balance_check() trait functions for the Mixer object in "oscps-lib/src/blocks.rs". 

Essentially these two functions will get different of IN - OUT and make sure that is lower than a tolerance. If TRUE, then it is in steady state. if FALSE, then it means that it is still in the dynamic state.